### PR TITLE
 Make ConjunctionMatcher Work For Null Values, fixes #16 

### DIFF
--- a/main/src/main/java/org/hobsoft/hamcrest/compose/ConjunctionMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/ConjunctionMatcher.java
@@ -18,7 +18,6 @@ import java.util.List;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -41,7 +40,7 @@ import static java.util.Objects.requireNonNull;
  *            the type of the object to be matched
  * @see ComposeMatchers#compose(Matcher...)
  */
-public final class ConjunctionMatcher<T> extends TypeSafeDiagnosingMatcher<T>
+public final class ConjunctionMatcher<T> extends TypeAndNullSafeDiagnosingMatcher<T>
 {
 	// ----------------------------------------------------------------------------------------------------------------
 	// constants

--- a/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
@@ -2,9 +2,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
@@ -1,0 +1,68 @@
+package org.hobsoft.hamcrest.compose;
+
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.internal.ReflectiveTypeFinder;
+
+/**
+ * A copy of {@link org.hamcrest.TypeSafeDiagnosingMatcher}, uses the same mechanisms used by them, but propagates null 
+ * values, what can be desired in some cases.
+ *
+ * @param <T> 
+ *           type of object to be matched.
+ */
+public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatcher<T>
+{
+	// ----------------------------------------------------------------------------------------------------------------
+	// constants
+	// ----------------------------------------------------------------------------------------------------------------
+	
+	private static final ReflectiveTypeFinder TYPE_FINDER = 
+			new ReflectiveTypeFinder("matchesSafely", 2, 0);
+	
+	// ----------------------------------------------------------------------------------------------------------------
+	// fields
+	// ----------------------------------------------------------------------------------------------------------------
+	
+	private final Class<?> expectedType;
+	
+	// ----------------------------------------------------------------------------------------------------------------
+	// constructors
+	// ----------------------------------------------------------------------------------------------------------------
+	
+	/**
+	 * @see TypeSafeDiagnosingMatcher#TypeSafeDiagnosingMatcher().
+	 */
+	protected TypeAndNullSafeDiagnosingMatcher()
+	{
+		this.expectedType = TYPE_FINDER.findExpectedType(getClass());
+	}
+	
+	// ----------------------------------------------------------------------------------------------------------------
+	// abstract methods
+	// ----------------------------------------------------------------------------------------------------------------
+	
+	/**
+	 * Similar to {@link TypeSafeDiagnosingMatcher#matchesSafely(Object, Description)}, but propagates null values too.
+	 */
+	protected abstract boolean matchesSafely(T item, Description mismatchDescription);
+	
+	// ----------------------------------------------------------------------------------------------------------------
+	// Diagnosing methods
+	// ----------------------------------------------------------------------------------------------------------------
+	
+	/**
+	 * Receives an item and check for match if it is null or an instance of the desired class.
+	 *
+	 * @param item Object to be verified.
+	 * @return If the given item matches.
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public boolean matches(Object item, Description mismatchDescription) 
+	{
+		return (item == null || expectedType.isInstance(item)) 
+			&& matchesSafely((T) item, mismatchDescription);
+	}
+}

--- a/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
@@ -55,8 +55,12 @@ public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatc
 	/**
 	 * Receives an item and check for match if it is null or an instance of the desired class.
 	 *
-	 * @param item Object to be verified.
-	 * @return If the given item matches.
+	 * @param item 
+	 *            Object to be verified.
+	 * @param mismatchDescription
+	 *            Description for the mismatches to be appended into.
+	 * @return 
+	 *            If the given item matches.
 	 */
 	@Override
 	@SuppressWarnings("unchecked")

--- a/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/TypeAndNullSafeDiagnosingMatcher.java
@@ -1,8 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.hobsoft.hamcrest.compose;
 
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.internal.ReflectiveTypeFinder;
 
 /**
@@ -18,8 +30,8 @@ public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatc
 	// constants
 	// ----------------------------------------------------------------------------------------------------------------
 	
-	private static final ReflectiveTypeFinder TYPE_FINDER = 
-			new ReflectiveTypeFinder("matchesSafely", 2, 0);
+	private static final ReflectiveTypeFinder TYPE_FINDER =
+		new ReflectiveTypeFinder("matchesSafely", 2, 0);
 	
 	// ----------------------------------------------------------------------------------------------------------------
 	// fields
@@ -32,7 +44,7 @@ public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatc
 	// ----------------------------------------------------------------------------------------------------------------
 	
 	/**
-	 * @see TypeSafeDiagnosingMatcher#TypeSafeDiagnosingMatcher().
+	 * @see org.hamcrest.TypeSafeDiagnosingMatcher#TypeSafeDiagnosingMatcher().
 	 */
 	protected TypeAndNullSafeDiagnosingMatcher()
 	{
@@ -44,7 +56,8 @@ public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatc
 	// ----------------------------------------------------------------------------------------------------------------
 	
 	/**
-	 * Similar to {@link TypeSafeDiagnosingMatcher#matchesSafely(Object, Description)}, but propagates null values too.
+	 * Similar to {@link org.hamcrest.TypeSafeDiagnosingMatcher#matchesSafely(Object, Description)}, but propagates 
+	 * null values too.
 	 */
 	protected abstract boolean matchesSafely(T item, Description mismatchDescription);
 	
@@ -63,10 +76,16 @@ public abstract class TypeAndNullSafeDiagnosingMatcher<T> extends DiagnosingMatc
 	 *            If the given item matches.
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
-	public boolean matches(Object item, Description mismatchDescription) 
+	public boolean matches(Object item, Description mismatchDescription)
 	{
-		return (item == null || expectedType.isInstance(item)) 
-			&& matchesSafely((T) item, mismatchDescription);
+		if (item != null && !expectedType.isInstance(item))
+		{
+			return false;
+		}
+		
+		@SuppressWarnings("unchecked")
+		T castItem = (T) item;
+		
+		return matchesSafely(castItem, mismatchDescription);
 	}
 }

--- a/main/src/test/java/org/hobsoft/hamcrest/compose/ConjunctionMatcherTest.java
+++ b/main/src/test/java/org/hobsoft/hamcrest/compose/ConjunctionMatcherTest.java
@@ -21,6 +21,8 @@ import static java.util.Collections.emptyList;
 import static org.hamcrest.CoreMatchers.anything;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.StringDescription.asString;
 import static org.hobsoft.hamcrest.compose.ComposeMatchers.compose;
@@ -146,6 +148,22 @@ public class ConjunctionMatcherTest
 		ConjunctionMatcher<String> matcher = compose(startsWith("x")).and(endsWith("y"));
 		
 		assertThat(matcher.matches("z"), is(false));
+	}
+	
+	@Test
+	public void matchesWhenNullIsPassedPropagatesToMatcher()
+	{
+		ConjunctionMatcher<?> matcher = compose(is(nullValue()));
+		
+		assertThat(matcher.matches(null), is(true));
+	}
+	
+	@Test
+	public void matchesWhenNullIsPassedDontThrowNullPointerException()
+	{
+		ConjunctionMatcher<String> matcher = compose(is(notNullValue(String.class)));
+		
+		assertThat(matcher.matches(null), is(false));
 	}
 	
 	@Test


### PR DESCRIPTION
I created a minimal version of `TypeSafeDiagnosingMatcher` extending `DiagnosingMatcher` that accepts null values as parameter to matches.