### PR TITLE
Supply Compose With More Permissive Type, fixes #13

### DIFF
--- a/main/src/main/java/org/hobsoft/hamcrest/compose/ComposeMatchers.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/ComposeMatchers.java
@@ -57,7 +57,7 @@ public final class ComposeMatchers
 	 * @see ConjunctionMatcher
 	 */
 	@SafeVarargs
-	public static <T> ConjunctionMatcher<T> compose(Matcher<T>... matchers)
+	public static <T> ConjunctionMatcher<T> compose(Matcher<? super T>... matchers)
 	{
 		return compose(null, matchers);
 	}
@@ -81,7 +81,7 @@ public final class ComposeMatchers
 	 * @see ConjunctionMatcher
 	 */
 	@SafeVarargs
-	public static <T> ConjunctionMatcher<T> compose(String compositeDescription, Matcher<T>... matchers)
+	public static <T> ConjunctionMatcher<T> compose(String compositeDescription, Matcher<? super T>... matchers)
 	{
 		requireNonNull(matchers, "matchers");
 		
@@ -104,7 +104,7 @@ public final class ComposeMatchers
 	 * @return a matcher that can compose itself with further matchers
 	 * @see ConjunctionMatcher
 	 */
-	public static <T> ConjunctionMatcher<T> compose(Iterable<Matcher<T>> matchers)
+	public static <T> ConjunctionMatcher<T> compose(Iterable<Matcher<? super T>> matchers)
 	{
 		return compose(null, matchers);
 	}
@@ -127,7 +127,7 @@ public final class ComposeMatchers
 	 * @return a matcher that can compose itself with further matchers
 	 * @see ConjunctionMatcher
 	 */
-	public static <T> ConjunctionMatcher<T> compose(String compositeDescription, Iterable<Matcher<T>> matchers)
+	public static <T> ConjunctionMatcher<T> compose(String compositeDescription, Iterable<Matcher<? super T>> matchers)
 	{
 		requireNonNull(matchers, "matchers");
 		

--- a/main/src/main/java/org/hobsoft/hamcrest/compose/ConjunctionMatcher.java
+++ b/main/src/main/java/org/hobsoft/hamcrest/compose/ConjunctionMatcher.java
@@ -56,13 +56,13 @@ public final class ConjunctionMatcher<T> extends TypeSafeDiagnosingMatcher<T>
 
 	private final String compositeDescription;
 	
-	private final List<Matcher<T>> matchers;
+	private final List<Matcher<? super T>> matchers;
 	
 	// ----------------------------------------------------------------------------------------------------------------
 	// constructors
 	// ----------------------------------------------------------------------------------------------------------------
 
-	ConjunctionMatcher(String compositeDescription, Iterable<Matcher<T>> matchers)
+	ConjunctionMatcher(String compositeDescription, Iterable<Matcher<? super T>> matchers)
 	{
 		requireNonNull(matchers, "matchers");
 		matchers.forEach(matcher -> requireNonNull(matcher, "matcher"));
@@ -84,7 +84,7 @@ public final class ConjunctionMatcher<T> extends TypeSafeDiagnosingMatcher<T>
 	 *            the matcher to logically AND to this matcher
 	 * @return the composed matcher
 	 */
-	public ConjunctionMatcher<T> and(Matcher<T> matcher)
+	public ConjunctionMatcher<T> and(Matcher<? super T> matcher)
 	{
 		requireNonNull(matcher, "matcher");
 		
@@ -119,7 +119,7 @@ public final class ConjunctionMatcher<T> extends TypeSafeDiagnosingMatcher<T>
 	{
 		boolean matches = true;
 		
-		for (Matcher<T> matcher : matchers)
+		for (Matcher<? super T> matcher : matchers)
 		{
 			if (!matcher.matches(actual))
 			{

--- a/main/src/test/java/org/hobsoft/hamcrest/compose/ComposeMatchersTest.java
+++ b/main/src/test/java/org/hobsoft/hamcrest/compose/ComposeMatchersTest.java
@@ -126,7 +126,7 @@ public class ComposeMatchersTest
 	@Test(expected = NullPointerException.class)
 	public void composeWithNullMatcherListThrowsException()
 	{
-		compose("x", (List<Matcher<Object>>) null);
+		compose("x", (List<Matcher<? super Object>>) null);
 	}
 	
 	@Test(expected = NullPointerException.class)
@@ -138,11 +138,22 @@ public class ComposeMatchersTest
 	@Test
 	public void composeWithMatchersClonesList()
 	{
-		List<Matcher<String>> matchers = new ArrayList<>();
+		List<Matcher<? super String>> matchers = new ArrayList<>();
 		matchers.add(startsWith("y"));
 		
 		Matcher<String> actual = compose("x", matchers);
 		matchers.add(endsWith("z"));
+		
+		assertThat(actual.matches("y"), is(true));
+	}
+	
+	@Test
+	public void composeWithSupertypeMatcherListReturnsMatcher()
+	{
+		List<Matcher<? super String>> matchers = new ArrayList<>();
+		matchers.add(anything());
+		
+		Matcher<String> actual = compose("x", matchers);
 		
 		assertThat(actual.matches("y"), is(true));
 	}

--- a/main/src/test/java/org/hobsoft/hamcrest/compose/ConjunctionMatcherTest.java
+++ b/main/src/test/java/org/hobsoft/hamcrest/compose/ConjunctionMatcherTest.java
@@ -48,6 +48,17 @@ public class ConjunctionMatcherTest
 	}
 	
 	@Test
+	public void andWithSuperTypeMatcherReturnsCompositeMatcher()
+	{
+		ConjunctionMatcher<String> matcher = compose("x", anything("y"));
+		
+		ConjunctionMatcher<String> actual = matcher.and(anything("z"));
+		
+		assertThat(asString(actual), is("x y\n"
+			+ "          and z"));
+	}
+	
+	@Test
 	public void andPreservesMatcher()
 	{
 		ConjunctionMatcher<Object> matcher = compose("x", anything("y"));


### PR DESCRIPTION
Hey, I has some problems with generics types and couldn't make a `compose` method which accepted both `Iterable<Matcher<? super T>>` and `Iterable<Matcher<T>>`, so to avoid breaking the tests of people whom used `Iterable<Matcher<T>>`, I added a method called `composes` with this change on signature.

If there is no problem breaking compatibility, you can simply remove the `compose(Iterable<Matcher<T>>)` and change it to my new methods.

It is a change that I think will only affect a minority of the users as type inference will take care of it most of times, but even so, I think the choice is yours about this decision.

PS: I changed the varargs methods with the `? super T`, but only because it will not break anyone tests, as it has been added to the repository yesterday.