### PR TITLE
Infer feature name for method references

### DIFF
--- a/main/src/test/java/org/hobsoft/hamcrest/compose/HasFeatureMatcherTest.java
+++ b/main/src/test/java/org/hobsoft/hamcrest/compose/HasFeatureMatcherTest.java
@@ -69,6 +69,17 @@ public class HasFeatureMatcherTest
 	}
 	
 	@Test
+	public void describeToWhenNoNameUsesMethodReference()
+	{
+		Matcher<String> matcher = hasFeature(String::length, anything("y"));
+		StringDescription description = new StringDescription();
+
+		matcher.describeTo(description);
+
+		assertThat(description.toString(), is("length y"));
+	}
+
+	@Test
 	public void matchesWhenFeatureMatcherMatchesReturnsTrue()
 	{
 		Matcher<String> matcher = hasFeature("x", "y", String::length, equalTo(1));
@@ -104,6 +115,17 @@ public class HasFeatureMatcherTest
 		matcher.describeMismatch("a", description);
 		
 		assertThat(description.toString(), is("x y was <1>"));
+	}
+
+	@Test
+	public void describeMismatchWhenNoNameUsesMethodReference()
+	{
+		Matcher<String> matcher = hasFeature(String::length, nothing("y"));
+		StringDescription description = new StringDescription();
+
+		matcher.describeMismatch("a", description);
+
+		assertThat(description.toString(), is("length y was <1>"));
 	}
 
 	// ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This addresses one part of issue #6.

This is using a `SerializedLambda` in a fairly seamless way.  Any existing code using method references will have the method name used as the feature name.

This is achieved by adding the following overloads to `ComposeMatcher`
```java
public static <T, U> Matcher<T> hasFeature(SerializableFunction<T, U> featureFunction, Matcher<? super U> featureMatcher)
public static <T, U> Matcher<T> hasFeatureValue(SerializableFunction<T, U> featureFunction, U featureValue)
```
with the interface 
```java
public interface SerializableFunction<T, U> extends Function<T, U>, Serializable {}
```

The Java compiler will automatically generate a serialized form of a lambda from the method reference, and this is introspected to extract the name of the method reference.

If the introspection fails, it falls back to the original behaviour of `featureFunction.toString()`.

No calling code needs to be modified to take advantage of this behaviour.